### PR TITLE
allows multiple ipapers to be rendered within the same DOM

### DIFF
--- a/lib/scribd_fu.rb
+++ b/lib/scribd_fu.rb
@@ -230,13 +230,14 @@ module ScribdFu
 
     # Display the iPaper document in a view
     def display_ipaper(options = {})
+      id = options.delete(:id)
       <<-END
         <script type="text/javascript" src="http://www.scribd.com/javascripts/view.js"></script>
-        <div id="embedded_flash">#{options.delete(:alt)}</div>
+        <div id="embedded_flash#{id}">#{options.delete(:alt)}</div>
         <script type="text/javascript">
           var scribd_doc = scribd.Document.getDoc(#{ipaper_id}, '#{ipaper_access_key}');
           #{js_params(options)}
-          scribd_doc.write("embedded_flash");
+          scribd_doc.write("embedded_flash#{id}");
         </script>
       END
     end

--- a/spec/scribd_fu_spec.rb
+++ b/spec/scribd_fu_spec.rb
@@ -356,5 +356,10 @@ describe "Viewing an iPaper document" do
     @document.display_ipaper(options).should =~ /.*scribd_doc\.addParam\('hide_disabled_buttons', true\);.*/
   end
 
+  it "should support passing in an id for the div" do
+    options = {:id => 'abc123'}
+    @document.display_ipaper(options).should =~ /id="embedded_flashabc123"/
+  end
+
 end
 


### PR DESCRIPTION
removes ID collisions
totally optional, falls back to old behaviour (nil is ok, and won't change any existing ids)
