### PR TITLE
scribd_fu fails when the file name has accentuated characters

### DIFF
--- a/lib/scribd_fu.rb
+++ b/lib/scribd_fu.rb
@@ -108,7 +108,12 @@ module ScribdFu
 
     # Replace spaces with '%20' (needed by Paperclip models).
     def escape(str)
-      str.gsub(' ', '%20')
+      basename = File.basename(str, ".*")
+      File.join(File.dirname(str), "#{url_encode(basename)}#{File.extname(str)}").to_s
+    end
+
+    def url_encode(str)
+      str.to_s.gsub(/[^a-zA-Z0-9_\-.]/n){ sprintf("%%%02X", $&.unpack("C")[0]) }
     end
 
     # See if a URL is S3 or CloudFront based

--- a/spec/scribd_fu_spec.rb
+++ b/spec/scribd_fu_spec.rb
@@ -63,7 +63,7 @@ describe "An AttachmentFu model" do
           describe "and has spaces in the filename" do
             it "should sanitize the file path" do
               res = mock('response', :doc_id => 1, :access_key => "ASDF")
-              @scribd_user.should_receive(:upload).with(:file => "some%20filename%20with%20spaces", :access => 'access').and_return(res)
+              @scribd_user.should_receive(:upload).with(:file => "./some%20filename%20with%20spaces", :access => 'access').and_return(res)
               ScribdFu::upload(@document, "some filename with spaces")
             end
 
@@ -217,16 +217,23 @@ describe "A Paperclip model" do
             @attachment.stub!(:scribdable? => true)
           end
 
-          describe "and has spaces in the filename" do
+          describe "and has special characters in the filename" do
             before do
               @attached_file.stub!(:path => "/path/to/somewhere with spaces.pdf")
               @attachment.stub!(:update_attributes)
             end
 
-            it "should sanitize the file path" do
+            it "should sanitize the file path spaces" do
               res = mock('response', :doc_id => 1, :access_key => "ASDF")
               @scribd_user.should_receive(:upload).with(:file => "/path/to/somewhere%20with%20spaces.pdf", :access => 'access').and_return(res)
               ScribdFu::upload(@attachment, "/path/to/somewhere with spaces.pdf")
+            end
+
+            it "should sanitize the file path accented characters" do
+              res = mock('response', :doc_id => 1, :access_key => "ASDF")
+              @scribd_user.should_receive(:upload).with(:file => "/path/to/new%20l%C3%ADder.pdf",
+                                                        :access => 'access').and_return(res)
+              ScribdFu::upload(@attachment, "/path/to/new líder.pdf")
             end
 
           end


### PR DESCRIPTION
I fixed the `escape` method to url enconde all the characters (not only spaces).
