### PR TITLE
remove unused private method, js_params

### DIFF
--- a/lib/scribd_fu.rb
+++ b/lib/scribd_fu.rb
@@ -250,26 +250,6 @@ module ScribdFu
       END
     end
 
-
-    private
-
-      # Check and collect any Javascript params that might have been passed in
-      def js_params(options)
-        opt = []
-
-        options.each_pair do |k, v|
-          if Available_JS_Params.include?(k)
-            if v == true || v == false
-              opt << "scribd_doc.addParam('#{k}', #{v});"
-            else
-              opt << "scribd_doc.addParam('#{k}', '#{v}');"
-            end
-          end
-        end
-
-        opt.compact.join("\n")
-      end
-
   end
 
 end


### PR DESCRIPTION
This method is not used.  However, I may add a pull request to use the flash version optionally.  In this case you may want to hold off on merging this PR.   I'll let you know.
